### PR TITLE
Debug page extension display issue

### DIFF
--- a/src/page/pageextension/Fijacion.al
+++ b/src/page/pageextension/Fijacion.al
@@ -11,6 +11,12 @@ pageextension 92155 Fijacion extends "Ficha Orden Fijacion"
                 ApplicationArea = All;
                 SubPageLink = "Nº Orden" = field("Nº Orden"), "Valla Fijada" = const(false), "Es Qr" = const(true);
             }
+            part("Documentos"; "Documentos Orden Fijacion")
+            {
+                Caption = 'Documentos Adjuntos';
+                ApplicationArea = All;
+                SubPageLink = ID_Doc = field("Nº Orden");
+            }
             part("Correos"; "Sent Emails List Part")
 
             {

--- a/src/table/tableextension/DocumentAttachmentExt.al
+++ b/src/table/tableextension/DocumentAttachmentExt.al
@@ -1,0 +1,11 @@
+tableextension 50120 "Document Attachment Ext" extends "Document Attachment"
+{
+    fields
+    {
+        field(50000; "ID_Doc"; Integer)
+        {
+            Caption = 'ID Documento';
+            DataClassification = CustomerContent;
+        }
+    }
+}


### PR DESCRIPTION
Enable display of the document attachment page in the "Ficha Orden Fijacion" extension by adding it as a part and defining the `ID_Doc` field.

The document attachment page was not appearing in the "Ficha Orden Fijacion" extension because it was not added as a part in the layout. Furthermore, the `SubPageLink` used to filter the documents referenced the `ID_Doc` field, which was missing from the "Document Attachment" table.

---
<a href="https://cursor.com/background-agent?bcId=bc-05ce7b95-d9c4-4176-bba5-2872ab948b8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-05ce7b95-d9c4-4176-bba5-2872ab948b8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

